### PR TITLE
Update auth to newest version to remove pesky bug

### DIFF
--- a/fix_ldap.cmd
+++ b/fix_ldap.cmd
@@ -1,6 +1,0 @@
-npm rm ldapjs
-npm install git://github.com/mcavage/node-ldapjs.git
-
-npm rm passport-ldapauth 
-npm install passport-ldapauth --no-optional
-

--- a/fix_ldap.sh
+++ b/fix_ldap.sh
@@ -1,9 +1,0 @@
-#Remove nested dependency and update with the newest version
-#Ideally once these libraries are upgraded to work with
-#ldaps on newer versions of node, this will be eliminated
-
-npm rm ldapjs
-npm install git://github.com/mcavage/node-ldapjs.git
-
-npm rm passport-ldapauth 
-npm install passport-ldapauth --no-optional

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lodash": "^2.4.1",
     "mongoose": "~3.8.17",
     "morgan": "^1.5.1",
-    "passport": "~0.2.1",
-    "passport-ldapauth": "^0.3.1",
+    "passport": "^0.3.2",
+    "passport-ldapauth": "^0.4.0",
     "pooling": "^0.4.6",
     "request": "~2.47.0"
   },


### PR DESCRIPTION
The new versions of passport and ldapauth dependencies get rid of that nasty LDAPs bug. Going to test on the server before merging to make sure everything's okay. 
