### PR TITLE
Rename to isSentimentAnalysis

### DIFF
--- a/assets/js/analysis/show.controller.js
+++ b/assets/js/analysis/show.controller.js
@@ -254,11 +254,11 @@
         }
     };
 
-    $scope.visualizeParseTree = function(sentiment) {
+    $scope.visualizeParseTree = function(isSentimentAnalysis) {
 
       d3.select(".svg-container").remove();
         
-        var dataToConvert = angular.copy(sentiment? $scope.sentimentTreeData : $scope.depsTreeData);
+        var dataToConvert = angular.copy(isSentimentAnalysis ? $scope.sentimentTreeData : $scope.depsTreeData);
 
         data = convertData(dataToConvert);
         renderTree();
@@ -376,7 +376,7 @@
               })
               .style('font-size', '18px')
               .style('fill-opacity', 1);
-            if(!sentiment){
+            if(!isSentimentAnalysis){
             nodeEnter.append('text')
               .attr('y', function (d, i) {
                   return (d.pos == 'root') ? 0 : -30;


### PR DESCRIPTION
This control flow is pretty confusing, and the variable name doesn't do much to help that. Renamed for some additional clarification. Could probably clean this up if we make an enum of all the analysis types we have. Could be used to get rid of these sneaky boolean values. 

@meyersbs 